### PR TITLE
Handle startup configuration errors

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -28,8 +28,13 @@ def create_app(test_config=None):
 
     # Load instance configuration if it exists
     if test_config is None:
-        # Load the instance config if it exists when not testing
-        app.config.from_pyfile('config.py', silent=True)
+        config_path = os.path.join(app.instance_path, 'config.py')
+        if os.path.exists(config_path):
+            try:
+                app.config.from_pyfile('config.py', silent=False)
+            except Exception as e:
+                print(f"ERROR: Failed to load {config_path}: {e}", file=sys.stderr)
+                sys.exit(1)
     else:
         # Load the test config if passed in
         app.config.from_mapping(test_config)
@@ -37,7 +42,13 @@ def create_app(test_config=None):
     # Support for environment-specific config
     env = os.environ.get('FLASK_ENV', 'production')
     if env != 'production':
-        app.config.from_pyfile(f'config.{env}.py', silent=True)
+        env_config = os.path.join(app.instance_path, f'config.{env}.py')
+        if os.path.exists(env_config):
+            try:
+                app.config.from_pyfile(f'config.{env}.py', silent=False)
+            except Exception as e:
+                print(f"ERROR: Failed to load {env_config}: {e}", file=sys.stderr)
+                sys.exit(1)
 
     # Ensure the instance folder exists
     try:

--- a/run.py
+++ b/run.py
@@ -32,14 +32,23 @@ def main():
         from app.config import get_config
         config = get_config()
 
-        # Create necessary directories
+        # Create necessary directories with error handling
         root_dir = os.path.abspath(config['directories']['videos'])
         web_assets_dir = os.path.abspath(config['directories']['web_assets'])
         thumb_dir = os.path.join(web_assets_dir, "thumbnails")
 
-        os.makedirs(root_dir, exist_ok=True)
-        os.makedirs(web_assets_dir, exist_ok=True)
-        os.makedirs(thumb_dir, exist_ok=True)
+        try:
+            os.makedirs(root_dir, exist_ok=True)
+            os.makedirs(web_assets_dir, exist_ok=True)
+            os.makedirs(thumb_dir, exist_ok=True)
+        except OSError as e:
+            print(f"ERROR: Unable to create required directories: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        for path in (root_dir, web_assets_dir, thumb_dir):
+            if not (os.access(path, os.R_OK) and os.access(path, os.W_OK)):
+                print(f"ERROR: Insufficient permissions for directory {path}", file=sys.stderr)
+                sys.exit(1)
 
         # Print server information
         print(f"Homehub Configuration:")


### PR DESCRIPTION
## Summary
- verify directory permissions in the entrypoint
- fail early if instance config files cannot be loaded

## Testing
- `python -m py_compile run.py app/__init__.py app/utils/*.py`

------
https://chatgpt.com/codex/tasks/task_e_683f7eac78dc832796112f53e896be7b