### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="app/static/homehub.png" alt="HomeHub Logo" width="200" height="100" />
 
-A Flask-based Video-on-Demand server with mobile-frendly responsive UI, folder navigation, pagination, and flexible configuration.
+A Flask-based Video-on-Demand server with mobile-friendly responsive UI, folder navigation, pagination, and flexible configuration.
 
 ![Demo](https://bomjkolyadun.github.io/HomeHub/demo.gif)
 


### PR DESCRIPTION
## Summary
- correct a typo in README for mobile-friendly description

## Testing
- `grep -n mobile README.md`

------
https://chatgpt.com/codex/tasks/task_e_683fcb9ca7248327a41f304d6623bedd