### PR TITLE
Add server info endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,19 @@ Once running, access the server in your web browser:
 - Default URL: `http://localhost:8082/`
 - Replace 8082 with your configured port
 
+## API Endpoints
+
+### `/api/info`
+
+Returns JSON describing the running server configuration. Useful for quick
+diagnostics or to confirm the active settings.
+
+Example:
+
+```bash
+curl http://localhost:8082/api/info
+```
+
 ## Running Tests
 
 To run the automated test suite install the dependencies and execute `pytest`:

--- a/app/routes.py
+++ b/app/routes.py
@@ -167,3 +167,20 @@ def search():
         search_query=query,
         matched_folders=matched_folders
     )
+
+
+@main_bp.route("/api/info")
+def api_info():
+    """Return basic server configuration information."""
+    from flask import current_app, jsonify
+
+    config = current_app.config.get('VOD_CONFIG', {})
+    info = {
+        'environment': os.environ.get('FLASK_ENV', 'production'),
+        'directories': config.get('directories', {}),
+        'video': {
+            'extensions': config['video']['extensions'],
+            'per_page': config['video']['per_page']
+        }
+    }
+    return jsonify(info)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -45,3 +45,13 @@ def test_index_and_search_routes(tmp_path, monkeypatch):
     assert res.status_code == 200
     assert b"a.mp4" in res.data
 
+
+def test_api_info_route(tmp_path, monkeypatch):
+    app = create_test_app(tmp_path, monkeypatch)
+    client = app.test_client()
+    res = client.get("/api/info")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["video"]["per_page"] == 1
+    assert "directories" in data
+


### PR DESCRIPTION
## Summary
- expose config details via `/api/info`
- document `/api/info` route in README
- test the new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd33002b48327af602a4551f1b2a4