### PR TITLE
Add packaging and artifact workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [ main ]
+    tags: [ 'v*' ]
   pull_request:
     branches: [ main ]
 
@@ -25,3 +26,14 @@ jobs:
         pip install pytest
     - name: Run tests
       run: pytest
+    - name: Build wheel
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        python -m pip install build
+        python -m build --wheel
+    - name: Upload artifact
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: actions/upload-artifact@v3
+      with:
+        name: homehub-${{ github.ref_name }}
+        path: dist/*.whl

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include app/templates *
+recursive-include app/static *
+include run.py

--- a/README.md
+++ b/README.md
@@ -46,10 +46,27 @@ Download from [https://ffmpeg.org/download.html](https://ffmpeg.org/download.htm
 choco install ffmpeg
 ```
 
+
 **Verify Installation:**
 
 ```bash
 ffmpeg -version
+```
+
+## Installation
+
+Build the project into a wheel using [build](https://pypi.org/project/build/):
+
+```bash
+python -m pip install build
+python -m build --wheel
+```
+
+Install the generated wheel and start the server with the `homehub` command:
+
+```bash
+pip install dist/homehub-*.whl
+homehub
 ```
 
 ## Configuration System

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "homehub"
+version = "0.1.0"
+description = "A Flask-based Video-on-Demand server with mobile-friendly UI"
+readme = "README.md"
+requires-python = ">=3.7"
+dependencies = [
+    "Flask==2.2.5",
+    "Werkzeug==3.0.6",
+    "Jinja2==3.1.6",
+    "MarkupSafe==2.1.2",
+    "click==8.1.3",
+    "itsdangerous==2.1.2",
+]
+
+[project.scripts]
+homehub = "run:main"
+
+[tool.setuptools]
+package-dir = {"" = "."}
+packages = ["app"]
+include-package-data = true


### PR DESCRIPTION
## Summary
- add `pyproject.toml` for building a wheel
- package templates and static files via `MANIFEST.in`
- document how to build and install the package
- update CI to build a wheel and upload it as an artifact when a tag is pushed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fcbfbb1f48327be61ce88dc363c71