### PR TITLE
Fix Bonjour/mDNS discovery

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,61 @@
+# Copilot Custom Instructions for This Project
+
+## 1. Use Python Virtual Environment (venv)
+
+- Always use a Python virtual environment for running, testing, and installing dependencies in this project.
+
+- To create a venv (if not present):
+
+  ```sh
+  python3 -m venv venv
+  ```
+
+- To activate the venv (macOS/Linux):
+
+  ```sh
+  source venv/bin/activate
+  ```
+
+- To install dependencies:
+
+  ```sh
+  pip install -r requirements.txt
+  ```
+
+- All terminal commands for Python should assume the venv is activated.
+
+## 2. Project Structure
+
+- Main entry point: `run.py`
+- App code: `app/`
+- Utilities: `app/utils/`
+- Configurations: `app/config.py`, `instance/`
+- Templates: `app/templates/`
+- Static files: `app/static/`
+
+## 3. Configuration
+
+- Use `instance/config.py` for local overrides. Prefer development environment settings.
+- Default config: `app/default_config.py`
+
+## 4. Testing & Linting
+
+- Use `pytest` for tests (if tests are added).
+- Use `flake8` or `black` for linting/formatting (if desired, add to requirements.txt).
+
+## 5. Environment Variables
+
+- Sensitive or environment-specific settings should be set via environment variables or in `instance/config.py` (not committed).
+
+## 6. General
+
+- Do not commit `venv/`, `__pycache__/`, or any secrets.
+- Update `requirements.txt` after installing new packages:
+
+  ```sh
+  pip freeze > requirements.txt
+  ```
+
+---
+
+*These instructions are for GitHub Copilot and developers working on this project.*

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,7 +55,3 @@
   ```sh
   pip freeze > requirements.txt
   ```
-
----
-
-*These instructions are for GitHub Copilot and developers working on this project.*

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -1,0 +1,346 @@
+# HomeHub VOD Server API Documentation
+
+## Overview
+
+The HomeHub VOD Server provides a RESTful API for browsing, searching, and streaming video files. The API supports both JSON and HTML responses, with JSON responses available by adding `?format=json` parameter or setting the `Accept: application/json` header.
+
+**Base URL:** `http://127.0.0.1:5000`
+
+## Authentication
+
+Currently, no authentication is required for API access.
+
+## Content Negotiation
+
+All endpoints that return HTML by default can return JSON by:
+
+- Adding `?format=json` query parameter
+- Setting `Accept: application/json` header
+
+## Endpoints
+
+### 1. Server Information
+
+```http
+GET /api/info
+```
+
+Get server configuration and available endpoints.
+
+**Response:**
+
+```json
+{
+  "server": {
+    "name": "HomeHub VOD Server",
+    "version": "1.0.0",
+    "video_extensions": [".mp4", ".mov", ".mkv", ".avi", ".m4v", ".webm", ".flv", ".wmv"],
+    "videos_per_page": 10
+  },
+  "endpoints": {
+    "videos": "/?format=json",
+    "search": "/search?format=json",
+    "folders": "/folders",
+    "refresh_cache": "/refresh"
+  }
+}
+```
+
+### 2. List Videos
+
+```http
+GET /?format=json
+GET /?format=json&page={page_number}
+```
+
+Get paginated list of all videos.
+
+**Parameters:**
+
+- `format` (optional): Set to "json" for JSON response
+- `page` (optional): Page number for pagination (default: 1)
+
+**Response:**
+
+```json
+{
+  "videos": [
+    {
+      "id": "folder/video.mp4",
+      "name": "video.mp4",
+      "path": "folder/video.mp4",
+      "size": 0,
+      "duration": "Unknown",
+      "thumbnail_url": "/thumb/folder_video.mp4.jpg",
+      "stream_url": "/video/folder/video.mp4",
+      "folder": "folder",
+      "modified_time": null
+    }
+  ],
+  "folders": [
+    {
+      "name": "folder_name",
+      "path": "folder_name"
+    }
+  ],
+  "pagination": {
+    "current_page": 1,
+    "total_pages": 38,
+    "total_videos": 372,
+    "per_page": 10
+  },
+  "current_folder": ""
+}
+```
+
+### 3. Browse Folder
+
+```http
+GET /folder/{folder_path}?format=json
+GET /folder/{folder_path}?format=json&page={page_number}
+```
+
+Get videos within a specific folder.
+
+**Parameters:**
+
+- `folder_path`: URL-encoded path to the folder
+- `format` (optional): Set to "json" for JSON response
+- `page` (optional): Page number for pagination (default: 1)
+
+**Response:**
+
+Same structure as List Videos, but filtered to the specified folder.
+
+### 4. List Folders
+
+```http
+GET /folders
+```
+
+Get list of all available folders (JSON only endpoint).
+
+**Response:**
+
+```json
+{
+  "folders": [
+    {
+      "name": "folder1",
+      "path": "folder1"
+    },
+    {
+      "name": "folder2",
+      "path": "folder2"
+    }
+  ],
+  "total_folders": 16
+}
+```
+
+### 5. Search Videos
+
+```http
+GET /search?format=json&q={query}
+GET /search?format=json&q={query}&page={page_number}
+```
+
+Search videos and folders by name.
+
+**Parameters:**
+
+- `q`: Search query string
+- `format` (optional): Set to "json" for JSON response
+- `page` (optional): Page number for pagination (default: 1)
+
+**Response:**
+
+```json
+{
+  "query": "search_term",
+  "results": {
+    "videos": [
+      {
+        "id": "folder/matching_video.mp4",
+        "name": "matching_video.mp4",
+        "path": "folder/matching_video.mp4",
+        "size": 0,
+        "duration": "Unknown",
+        "thumbnail_url": "/thumb/folder_matching_video.mp4.jpg",
+        "stream_url": "/video/folder/matching_video.mp4",
+        "folder": "folder",
+        "modified_time": null
+      }
+    ],
+    "folders": [
+      {
+        "name": "matching_folder",
+        "path": "matching_folder"
+      }
+    ]
+  },
+  "pagination": {
+    "current_page": 1,
+    "total_pages": 15,
+    "total_videos": 142,
+    "per_page": 10
+  },
+  "total_results": 144
+}
+```
+
+### 6. Stream Video
+
+```http
+GET /video/{video_path}
+```
+
+Stream a video file.
+
+**Parameters:**
+
+- `video_path`: URL-encoded relative path to the video file
+
+**Response:**
+
+- Binary video stream
+- Content-Type set based on file extension
+- Supports HTTP range requests for seeking
+
+### 7. Get Thumbnail
+
+```http
+GET /thumb/{thumbnail_filename}
+```
+
+Get thumbnail image for a video.
+
+**Parameters:**
+
+- `thumbnail_filename`: Generated thumbnail filename
+
+**Response:**
+
+- Binary image data (typically JPEG)
+
+### 8. Refresh Cache
+
+```http
+GET /refresh
+```
+
+Refresh the video cache (scans for new/deleted files).
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "message": "Video cache refreshed successfully!"
+}
+```
+
+## Video Object Schema
+
+Each video object in API responses contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique identifier (relative path) |
+| `name` | string | Filename |
+| `path` | string | Relative path from videos root |
+| `size` | number | File size in bytes |
+| `duration` | string | Video duration (currently "Unknown") |
+| `thumbnail_url` | string\|null | URL to thumbnail image |
+| `stream_url` | string | URL to stream the video |
+| `folder` | string\|null | Parent folder name |
+| `modified_time` | string\|null | Last modified timestamp |
+
+## Pagination Schema
+
+Pagination information is included in list responses:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `current_page` | number | Current page number |
+| `total_pages` | number | Total number of pages |
+| `total_videos` | number | Total number of videos |
+| `per_page` | number | Videos per page (default: 10) |
+
+## Error Responses
+
+### 404 Not Found
+
+Returned when requesting non-existent endpoints or files.
+
+```html
+<!doctype html>
+<html lang=en>
+<title>404 Not Found</title>
+<h1>Not Found</h1>
+<p>The requested URL was not found on the server.</p>
+```
+
+## Example Usage
+
+### cURL Examples
+
+```bash
+# Get server info
+curl "http://127.0.0.1:5000/api/info"
+
+# List all videos (first page)
+curl "http://127.0.0.1:5000/?format=json"
+
+# Get second page of videos
+curl "http://127.0.0.1:5000/?format=json&page=2"
+
+# Browse specific folder
+curl "http://127.0.0.1:5000/folder/angelsetfree?format=json"
+
+# Search for videos containing "angel"
+curl "http://127.0.0.1:5000/search?format=json&q=angel"
+
+# Get all folders
+curl "http://127.0.0.1:5000/folders"
+
+# Refresh cache
+curl "http://127.0.0.1:5000/refresh"
+
+# Stream a video
+curl "http://127.0.0.1:5000/video/folder/video.mp4" -o video.mp4
+```
+
+### JavaScript Fetch Examples
+
+```javascript
+// Get server info
+const serverInfo = await fetch('/api/info').then(r => r.json());
+
+// List videos with pagination
+const videos = await fetch('/?format=json&page=1').then(r => r.json());
+
+// Search videos
+const searchResults = await fetch('/search?format=json&q=angel').then(r => r.json());
+
+// Get folders
+const folders = await fetch('/folders').then(r => r.json());
+
+// Refresh cache
+const refreshResult = await fetch('/refresh').then(r => r.json());
+```
+
+## Rate Limiting
+
+Currently, no rate limiting is implemented.
+
+## CORS
+
+Cross-Origin Resource Sharing (CORS) headers are not explicitly set. The server accepts requests from any origin when running in development mode.
+
+## Notes
+
+- Video duration extraction is not currently implemented (always returns "Unknown")
+- File sizes are not populated (always return 0)
+- Thumbnail generation requires ffmpeg to be installed
+- The server supports common video formats: MP4, MOV, MKV, AVI, M4V, WebM, FLV, WMV

--- a/app/default_config.py
+++ b/app/default_config.py
@@ -8,7 +8,8 @@ DEFAULT_VOD_CONFIG = {
     "server": {
         "port": 8080,
         "host": "0.0.0.0",
-        "debug": False
+        "debug": False,
+        "name": "HomeHub"  # Service name for discovery
     },
     "directories": {
         "videos": "../vids",
@@ -20,5 +21,9 @@ DEFAULT_VOD_CONFIG = {
     },
     "cache": {
         "ttl_seconds": 300
+    },
+    "discovery": {
+        "enabled": True,
+        "service_name": "HomeHub"
     }
 }

--- a/app/routes.py
+++ b/app/routes.py
@@ -235,8 +235,8 @@ def search():
 @main_bp.route("/folders")
 def list_folders():
     """Get list of all folders (JSON only endpoint)"""
-    from flask import current_app
-    config = current_app.config.get('VOD_CONFIG', {})
+    from app.config import get_config
+    config = get_config()
     root_dir = os.path.abspath(config['directories']['videos'])
     
     folders = get_folders(root_dir)
@@ -264,25 +264,27 @@ def _discovery_payload(config):
     }
 
 
+def _local_server_ip():
+    import socket
+
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.connect(("8.8.8.8", 80))
+            return sock.getsockname()[0]
+    except OSError:
+        return "localhost"
+
+
 @main_bp.route("/api/info")
 def server_info():
     """Get server information (JSON only endpoint)"""
     from flask import current_app
-    import socket
-    
-    # Log the request for debugging
-    print(f"API Info request from: {request.remote_addr}, User-Agent: {request.headers.get('User-Agent', 'Unknown')}")
-    
-    config = current_app.config.get('VOD_CONFIG', {})
-    
-    # Get server IP address
-    try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.connect(("8.8.8.8", 80))
-        server_ip = s.getsockname()[0]
-        s.close()
-    except:
-        server_ip = "localhost"
+    from app.config import get_config
+
+    current_app.logger.debug("API info request from %s", request.remote_addr)
+
+    config = get_config()
+    server_ip = _local_server_ip()
     
     response_data = {
         'server': {

--- a/app/routes.py
+++ b/app/routes.py
@@ -246,6 +246,24 @@ def list_folders():
         'total_folders': len(folders)
     })
 
+def _discovery_payload(config):
+    from app.utils.service_discovery import (
+        SERVICE_TYPE,
+        discovery_hostname_for,
+        get_discovery_status,
+    )
+
+    status = get_discovery_status()
+    if status:
+        return status
+
+    service_name = config.get('discovery', {}).get('service_name', 'HomeHub')
+    return {
+        'bonjour_service': discovery_hostname_for(service_name),
+        'service_type': SERVICE_TYPE,
+    }
+
+
 @main_bp.route("/api/info")
 def server_info():
     """Get server information (JSON only endpoint)"""
@@ -275,10 +293,7 @@ def server_info():
             'video_extensions': config['video']['extensions'],
             'videos_per_page': config['video']['per_page']
         },
-        'discovery': {
-            'bonjour_service': f"{config.get('discovery', {}).get('service_name', 'HomeHub')}.local",
-            'service_type': '_homehub._tcp.local.'
-        },
+        'discovery': _discovery_payload(config),
         'endpoints': {
             'videos': '/?format=json',
             'search': '/search?format=json',

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,7 +1,7 @@
 """
 Route definitions for the VOD application.
 """
-from flask import Blueprint, render_template, send_from_directory, request, abort
+from flask import Blueprint, render_template, send_from_directory, request, abort, jsonify
 import os
 import urllib.parse
 import math
@@ -12,6 +12,37 @@ from app.utils.video_utils import generate_thumbnail
 
 # Create blueprint
 main_bp = Blueprint('main', __name__)
+
+# Helper function to detect JSON requests
+def wants_json():
+    """Check if the request wants JSON response"""
+    # Check for explicit format parameter
+    if request.args.get('format') == 'json':
+        return True
+    
+    # Check Accept header
+    return (request.headers.get('Accept', '').find('application/json') > 
+            request.headers.get('Accept', '').find('text/html'))
+
+# Helper function to format video data for JSON
+def format_video_for_json(video, base_url=''):
+    """Format video data for JSON response"""
+    return {
+        'id': video['rel_path'],  # Use relative path as ID
+        'name': video['filename'],
+        'path': video['rel_path'],
+        'size': video.get('size', 0),
+        'duration': video.get('duration', 'Unknown'),
+        'thumbnail_url': f"/thumb/{video['thumb']}" if video.get('thumb') else None,
+        'stream_url': f"/video/{urllib.parse.quote(video['rel_path'])}",
+        'folder': os.path.dirname(video['rel_path']) or None,
+        'modified_time': video.get('modified_time')
+    }
+
+# Helper function to format folders for JSON
+def format_folders_for_json(folders):
+    """Format folder data for JSON response"""
+    return [{'name': folder, 'path': folder} for folder in folders]
 
 # Access app config
 def get_config():
@@ -49,7 +80,7 @@ def setup_app_before_first_request():
 @main_bp.route("/")
 @main_bp.route("/folder/<path:folder>")
 def index(folder=''):
-    """Main page route handling folder navigation"""
+    """Main page route handling folder navigation with JSON support"""
     from flask import current_app
     config = current_app.config.get('VOD_CONFIG', {})
     
@@ -67,6 +98,21 @@ def index(folder=''):
     )
     folders = get_folders(root_dir)
     
+    # Return JSON if requested
+    if wants_json():
+        return jsonify({
+            'videos': [format_video_for_json(video) for video in pagination_data['videos']],
+            'folders': format_folders_for_json(folders),
+            'pagination': {
+                'current_page': pagination_data['current_page'],
+                'total_pages': pagination_data['total_pages'],
+                'total_videos': pagination_data['total_videos'],
+                'per_page': videos_per_page
+            },
+            'current_folder': pagination_data['current_folder']
+        })
+    
+    # Return HTML template for browser requests
     return render_template(
         "video_template.html",
         videos=pagination_data['videos'],
@@ -126,7 +172,7 @@ def refresh_cache():
 
 @main_bp.route("/search")
 def search():
-    """Search videos and folders by name"""
+    """Search videos and folders by name with JSON support"""
     from flask import current_app
     config = current_app.config.get('VOD_CONFIG', {})
     root_dir = os.path.abspath(config['directories']['videos'])
@@ -156,6 +202,24 @@ def search():
     folders = get_folders(root_dir)
     matched_folders = [f for f in folders if query in f.lower()]
 
+    # Return JSON if requested
+    if wants_json():
+        return jsonify({
+            'query': query,
+            'results': {
+                'videos': [format_video_for_json(video) for video in paginated_videos],
+                'folders': [{'name': folder, 'path': folder} for folder in matched_folders]
+            },
+            'pagination': {
+                'current_page': page,
+                'total_pages': total_pages,
+                'total_videos': total_videos,
+                'per_page': videos_per_page
+            },
+            'total_results': len(matched_videos) + len(matched_folders)
+        })
+
+    # Return HTML template for browser requests
     return render_template(
         "video_template.html",
         videos=paginated_videos,
@@ -167,3 +231,55 @@ def search():
         search_query=query,
         matched_folders=matched_folders
     )
+
+@main_bp.route("/folders")
+def list_folders():
+    """Get list of all folders (JSON only endpoint)"""
+    from flask import current_app
+    config = current_app.config.get('VOD_CONFIG', {})
+    root_dir = os.path.abspath(config['directories']['videos'])
+    
+    folders = get_folders(root_dir)
+    
+    return jsonify({
+        'folders': format_folders_for_json(folders),
+        'total_folders': len(folders)
+    })
+
+@main_bp.route("/api/info")
+def server_info():
+    """Get server information (JSON only endpoint)"""
+    from flask import current_app
+    import socket
+    
+    config = current_app.config.get('VOD_CONFIG', {})
+    
+    # Get server IP address
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(("8.8.8.8", 80))
+        server_ip = s.getsockname()[0]
+        s.close()
+    except:
+        server_ip = "localhost"
+    
+    return jsonify({
+        'server': {
+            'name': config.get('server', {}).get('name', 'HomeHub'),
+            'version': '1.0.0',
+            'host': server_ip,
+            'port': config.get('server', {}).get('port', 8080),
+            'video_extensions': config['video']['extensions'],
+            'videos_per_page': config['video']['per_page']
+        },
+        'discovery': {
+            'bonjour_service': f"{config.get('discovery', {}).get('service_name', 'HomeHub')}.local",
+            'service_type': '_http._tcp.local.'
+        },
+        'endpoints': {
+            'videos': '/?format=json',
+            'search': '/search?format=json',
+            'folders': '/folders',
+            'refresh_cache': '/refresh'
+        }
+    })

--- a/app/routes.py
+++ b/app/routes.py
@@ -252,6 +252,9 @@ def server_info():
     from flask import current_app
     import socket
     
+    # Log the request for debugging
+    print(f"API Info request from: {request.remote_addr}, User-Agent: {request.headers.get('User-Agent', 'Unknown')}")
+    
     config = current_app.config.get('VOD_CONFIG', {})
     
     # Get server IP address
@@ -263,7 +266,7 @@ def server_info():
     except:
         server_ip = "localhost"
     
-    return jsonify({
+    response_data = {
         'server': {
             'name': config.get('server', {}).get('name', 'HomeHub'),
             'version': '1.0.0',
@@ -274,7 +277,7 @@ def server_info():
         },
         'discovery': {
             'bonjour_service': f"{config.get('discovery', {}).get('service_name', 'HomeHub')}.local",
-            'service_type': '_http._tcp.local.'
+            'service_type': '_homehub._tcp.local.'
         },
         'endpoints': {
             'videos': '/?format=json',
@@ -282,4 +285,21 @@ def server_info():
             'folders': '/folders',
             'refresh_cache': '/refresh'
         }
-    })
+    }
+    
+    # Create response with CORS headers
+    response = jsonify(response_data)
+    response.headers.add('Access-Control-Allow-Origin', '*')
+    response.headers.add('Access-Control-Allow-Headers', 'Content-Type,Authorization')
+    response.headers.add('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS')
+    
+    return response
+
+@main_bp.route("/api/info", methods=['OPTIONS'])
+def server_info_options():
+    """Handle preflight OPTIONS requests for CORS"""
+    response = jsonify({'status': 'ok'})
+    response.headers.add('Access-Control-Allow-Origin', '*')
+    response.headers.add('Access-Control-Allow-Headers', 'Content-Type,Authorization')
+    response.headers.add('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS')
+    return response

--- a/app/utils/service_discovery.py
+++ b/app/utils/service_discovery.py
@@ -77,6 +77,7 @@ class BonjourService:
         }
         txt_properties = {k: str(v).encode("utf-8") for k, v in properties.items()}
 
+        self.zeroconf = None
         try:
             self.service_info = ServiceInfo(
                 SERVICE_TYPE,
@@ -94,8 +95,7 @@ class BonjourService:
             registered_name = self.service_info.name or service_instance
             if not registered_name.endswith("."):
                 registered_name = f"{registered_name}."
-            instance_label = registered_name[: -len(SERVICE_TYPE)].rstrip(".")
-            self.registered_hostname = f"{instance_label}.local"
+            self.registered_hostname = f"{hostname_label}.local"
             self.registered_service_name = registered_name
 
             logger.info("HomeHub Bonjour service registered: %s", registered_name)
@@ -103,6 +103,20 @@ class BonjourService:
             logger.info("  Hostname: %s", self.registered_hostname)
         except Exception:
             logger.exception("Failed to register Bonjour service")
+            self._clear_registration()
+
+    def _clear_registration(self):
+        """Release zeroconf resources without treating the service as active."""
+        if self.zeroconf:
+            try:
+                self.zeroconf.close()
+            except Exception:
+                logger.exception("Error closing Bonjour client after registration failure")
+        self.zeroconf = None
+        self.service_info = None
+        self._running = False
+        self.registered_hostname = None
+        self.registered_service_name = None
 
     def unregister_service(self):
         """Unregister the service"""
@@ -117,10 +131,7 @@ class BonjourService:
         except Exception:
             logger.exception("Error unregistering Bonjour service")
         finally:
-            self.zeroconf = None
-            self.service_info = None
-            self.registered_hostname = None
-            self.registered_service_name = None
+            self._clear_registration()
 
     def __del__(self):
         self.unregister_service()

--- a/app/utils/service_discovery.py
+++ b/app/utils/service_discovery.py
@@ -40,8 +40,8 @@ class BonjourService:
             clean_server_name = server_name.replace(' ', '-').replace('_', '-')
             unique_server_name = f"{clean_server_name}-{os.getpid()}"
             
-            # Service type for HTTP servers
-            service_type = "_http._tcp.local."
+            # Custom service type for HomeHub servers
+            service_type = "_homehub._tcp.local."
             service_name = f"{unique_server_name}.{service_type}"
             
             # Service properties (TXT records)

--- a/app/utils/service_discovery.py
+++ b/app/utils/service_discovery.py
@@ -1,122 +1,142 @@
 """
 Service discovery utilities using Bonjour/mDNS
 """
+import logging
+import re
 import socket
-import threading
-import time
+from typing import Optional
+
 from zeroconf import ServiceInfo, Zeroconf
+
+logger = logging.getLogger(__name__)
+
+SERVICE_TYPE = "_homehub._tcp.local."
+
+
+def _sanitize_dns_label(name: str, fallback: str = "homehub") -> str:
+    """Normalize a string for use as an mDNS host/service label."""
+    label = name.strip().replace(" ", "-").replace("_", "-")
+    label = re.sub(r"[^a-zA-Z0-9-]", "-", label)
+    label = re.sub(r"-+", "-", label).strip("-").lower()
+    return (label or fallback)[:63]
+
+
+def _local_ip_for_discovery(bind_host: str) -> Optional[str]:
+    """Return the LAN address to publish in mDNS records."""
+    if bind_host not in ("0.0.0.0", "127.0.0.1", "::", "::1"):
+        return bind_host
+
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.connect(("8.8.8.8", 80))
+            return sock.getsockname()[0]
+    except OSError:
+        return None
+
 
 class BonjourService:
     """Bonjour/mDNS service registration for HomeHub server"""
-    
+
     def __init__(self):
         self.zeroconf = None
         self.service_info = None
-        self._thread = None
         self._running = False
-        
+        self.registered_hostname = None
+        self.registered_service_name = None
+
     def register_service(self, host, port, server_name="HomeHub"):
         """
         Register the HomeHub service with Bonjour/mDNS
-        
+
         Args:
-            host (str): Server host/IP address
+            host (str): Server host/IP address Flask binds to
             port (int): Server port
             server_name (str): Display name for the service
         """
+        if host in ("127.0.0.1", "::1"):
+            logger.warning(
+                "Skipping Bonjour registration: server is bound to %s (not reachable on the LAN)",
+                host,
+            )
+            return
+
+        local_ip = _local_ip_for_discovery(host)
+        if not local_ip:
+            logger.error("Could not determine local IP address for Bonjour advertisement")
+            return
+
+        hostname_label = _sanitize_dns_label(server_name)
+        service_instance = f"{hostname_label}.{SERVICE_TYPE}"
+
+        properties = {
+            "name": server_name,
+            "type": "HomeHub VOD Server",
+            "version": "1.0.0",
+            "path": "/",
+            "api": "/api/info",
+        }
+        txt_properties = {k: str(v).encode("utf-8") for k, v in properties.items()}
+
         try:
-            # Get local IP address if host is 0.0.0.0
-            if host == "0.0.0.0":
-                # Get the local IP address
-                s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                s.connect(("8.8.8.8", 80))
-                local_ip = s.getsockname()[0]
-                s.close()
-            else:
-                local_ip = host
-            
-            # Clean up server name for DNS compatibility and make unique
-            import os
-            clean_server_name = server_name.replace(' ', '-').replace('_', '-')
-            unique_server_name = f"{clean_server_name}-{os.getpid()}"
-            
-            # Custom service type for HomeHub servers
-            service_type = "_homehub._tcp.local."
-            service_name = f"{unique_server_name}.{service_type}"
-            
-            # Service properties (TXT records)
-            properties = {
-                'name': server_name,
-                'type': 'HomeHub VOD Server',
-                'version': '1.0.0',
-                'path': '/',
-                'api': '/api/info'
-            }
-            
-            # Convert string values to bytes for TXT records
-            txt_properties = {k: str(v).encode('utf-8') for k, v in properties.items()}
-            
-            # Create service info
             self.service_info = ServiceInfo(
-                service_type,
-                service_name,
+                SERVICE_TYPE,
+                service_instance,
                 addresses=[socket.inet_aton(local_ip)],
                 port=port,
                 properties=txt_properties,
-                server=f"{unique_server_name}.local."
+                server=f"{hostname_label}.local.",
             )
-            
-            # Initialize zeroconf
+
             self.zeroconf = Zeroconf()
-            
-            # Register the service in main thread to avoid threading issues
-            self._register_service_sync()
-            
-            print(f"✅ HomeHub service registered: {service_name}")
-            print(f"   Host: {local_ip}:{port}")
-            print(f"   Service: {service_type}")
-            print(f"   Discoverable as: {unique_server_name}.local")
-            
-        except Exception as e:
-            import traceback
-            print(f"❌ Failed to register Bonjour service: {e}")
-            print(f"Full traceback: {traceback.format_exc()}")
-    
-    def _register_service_sync(self):
-        """Register service synchronously"""
-        try:
-            self.zeroconf.register_service(self.service_info)
+            self.zeroconf.register_service(self.service_info, allow_name_change=True)
             self._running = True
-            print(f"✅ Service registration completed successfully")
-        except Exception as e:
-            import traceback
-            print(f"❌ Error in service registration: {e}")
-            print(f"Full traceback: {traceback.format_exc()}")
-    
+
+            registered_name = self.service_info.name or service_instance
+            if not registered_name.endswith("."):
+                registered_name = f"{registered_name}."
+            instance_label = registered_name[: -len(SERVICE_TYPE)].rstrip(".")
+            self.registered_hostname = f"{instance_label}.local"
+            self.registered_service_name = registered_name
+
+            logger.info("HomeHub Bonjour service registered: %s", registered_name)
+            logger.info("  Address: %s:%s", local_ip, port)
+            logger.info("  Hostname: %s", self.registered_hostname)
+        except Exception:
+            logger.exception("Failed to register Bonjour service")
+
     def unregister_service(self):
         """Unregister the service"""
+        self._running = False
+        if not self.zeroconf or not self.service_info:
+            return
+
         try:
-            self._running = False
-            if self.zeroconf and self.service_info:
-                self.zeroconf.unregister_service(self.service_info)
-                self.zeroconf.close()
-                print("✅ HomeHub service unregistered")
-        except Exception as e:
-            print(f"❌ Error unregistering service: {e}")
-    
+            self.zeroconf.unregister_service(self.service_info)
+            self.zeroconf.close()
+            logger.info("HomeHub Bonjour service unregistered")
+        except Exception:
+            logger.exception("Error unregistering Bonjour service")
+        finally:
+            self.zeroconf = None
+            self.service_info = None
+            self.registered_hostname = None
+            self.registered_service_name = None
+
     def __del__(self):
-        """Cleanup when object is destroyed"""
         self.unregister_service()
 
-# Global service instance
+
 _bonjour_service = None
+
 
 def start_service_discovery(host, port, server_name="HomeHub"):
     """Start Bonjour/mDNS service discovery"""
     global _bonjour_service
+    stop_service_discovery()
     _bonjour_service = BonjourService()
     _bonjour_service.register_service(host, port, server_name)
     return _bonjour_service
+
 
 def stop_service_discovery():
     """Stop Bonjour/mDNS service discovery"""
@@ -124,3 +144,20 @@ def stop_service_discovery():
     if _bonjour_service:
         _bonjour_service.unregister_service()
         _bonjour_service = None
+
+
+def discovery_hostname_for(server_name: str) -> str:
+    """Predict the Bonjour hostname when discovery has not started yet."""
+    return f"{_sanitize_dns_label(server_name)}.local"
+
+
+def get_discovery_status():
+    """Return active Bonjour registration details for API consumers."""
+    if not _bonjour_service or not _bonjour_service._running:
+        return None
+
+    return {
+        "bonjour_service": _bonjour_service.registered_hostname,
+        "service_type": SERVICE_TYPE,
+        "service_name": _bonjour_service.registered_service_name,
+    }

--- a/app/utils/service_discovery.py
+++ b/app/utils/service_discovery.py
@@ -1,0 +1,126 @@
+"""
+Service discovery utilities using Bonjour/mDNS
+"""
+import socket
+import threading
+import time
+from zeroconf import ServiceInfo, Zeroconf
+
+class BonjourService:
+    """Bonjour/mDNS service registration for HomeHub server"""
+    
+    def __init__(self):
+        self.zeroconf = None
+        self.service_info = None
+        self._thread = None
+        self._running = False
+        
+    def register_service(self, host, port, server_name="HomeHub"):
+        """
+        Register the HomeHub service with Bonjour/mDNS
+        
+        Args:
+            host (str): Server host/IP address
+            port (int): Server port
+            server_name (str): Display name for the service
+        """
+        try:
+            # Get local IP address if host is 0.0.0.0
+            if host == "0.0.0.0":
+                # Get the local IP address
+                s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                s.connect(("8.8.8.8", 80))
+                local_ip = s.getsockname()[0]
+                s.close()
+            else:
+                local_ip = host
+            
+            # Clean up server name for DNS compatibility and make unique
+            import os
+            clean_server_name = server_name.replace(' ', '-').replace('_', '-')
+            unique_server_name = f"{clean_server_name}-{os.getpid()}"
+            
+            # Service type for HTTP servers
+            service_type = "_http._tcp.local."
+            service_name = f"{unique_server_name}.{service_type}"
+            
+            # Service properties (TXT records)
+            properties = {
+                'name': server_name,
+                'type': 'HomeHub VOD Server',
+                'version': '1.0.0',
+                'path': '/',
+                'api': '/api/info'
+            }
+            
+            # Convert string values to bytes for TXT records
+            txt_properties = {k: str(v).encode('utf-8') for k, v in properties.items()}
+            
+            # Create service info
+            self.service_info = ServiceInfo(
+                service_type,
+                service_name,
+                addresses=[socket.inet_aton(local_ip)],
+                port=port,
+                properties=txt_properties,
+                server=f"{unique_server_name}.local."
+            )
+            
+            # Initialize zeroconf
+            self.zeroconf = Zeroconf()
+            
+            # Register the service in main thread to avoid threading issues
+            self._register_service_sync()
+            
+            print(f"✅ HomeHub service registered: {service_name}")
+            print(f"   Host: {local_ip}:{port}")
+            print(f"   Service: {service_type}")
+            print(f"   Discoverable as: {unique_server_name}.local")
+            
+        except Exception as e:
+            import traceback
+            print(f"❌ Failed to register Bonjour service: {e}")
+            print(f"Full traceback: {traceback.format_exc()}")
+    
+    def _register_service_sync(self):
+        """Register service synchronously"""
+        try:
+            self.zeroconf.register_service(self.service_info)
+            self._running = True
+            print(f"✅ Service registration completed successfully")
+        except Exception as e:
+            import traceback
+            print(f"❌ Error in service registration: {e}")
+            print(f"Full traceback: {traceback.format_exc()}")
+    
+    def unregister_service(self):
+        """Unregister the service"""
+        try:
+            self._running = False
+            if self.zeroconf and self.service_info:
+                self.zeroconf.unregister_service(self.service_info)
+                self.zeroconf.close()
+                print("✅ HomeHub service unregistered")
+        except Exception as e:
+            print(f"❌ Error unregistering service: {e}")
+    
+    def __del__(self):
+        """Cleanup when object is destroyed"""
+        self.unregister_service()
+
+# Global service instance
+_bonjour_service = None
+
+def start_service_discovery(host, port, server_name="HomeHub"):
+    """Start Bonjour/mDNS service discovery"""
+    global _bonjour_service
+    _bonjour_service = BonjourService()
+    _bonjour_service.register_service(host, port, server_name)
+    return _bonjour_service
+
+def stop_service_discovery():
+    """Stop Bonjour/mDNS service discovery"""
+    global _bonjour_service
+    if _bonjour_service:
+        _bonjour_service.unregister_service()
+        _bonjour_service = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Jinja2==3.1.2
 MarkupSafe==2.1.2
 click==8.1.3
 itsdangerous==2.1.2
+zeroconf==0.47.1

--- a/run.py
+++ b/run.py
@@ -21,6 +21,7 @@ def cleanup_service():
     if _service_discovery:
         from app.utils.service_discovery import stop_service_discovery
         stop_service_discovery()
+        _service_discovery = None
 
 def signal_handler(signum, frame):
     """Handle shutdown signals"""
@@ -128,20 +129,29 @@ def main():
         logging.info(f"- Supported extensions: {', '.join(config['video']['extensions'])}")
         logging.info(f"- Videos per page: {config['video']['per_page']}")
 
-        # Start service discovery
-        if not args.no_discovery and config.get('discovery', {}).get('enabled', True):
+        # Start service discovery (skip werkzeug reloader parent to avoid duplicate ads)
+        discovery_enabled = (
+            not args.no_discovery
+            and config.get('discovery', {}).get('enabled', True)
+            and (not debug_mode or os.environ.get('WERKZEUG_RUN_MAIN') == 'true')
+        )
+        if discovery_enabled:
             try:
                 from app.utils.service_discovery import start_service_discovery
-                service_name = config.get('discovery', {}).get('service_name', config['server'].get('name', 'HomeHub'))
+                service_name = config.get('discovery', {}).get(
+                    'service_name', config['server'].get('name', 'HomeHub')
+                )
                 _service_discovery = start_service_discovery(
                     config['server']['host'],
                     config['server']['port'],
-                    service_name
+                    service_name,
                 )
             except ImportError:
-                logging.warning("⚠️  Service discovery not available. Install 'zeroconf' package for network discovery.")
+                logging.warning(
+                    "Service discovery not available. Install the 'zeroconf' package for network discovery."
+                )
             except Exception as e:
-                logging.warning(f"⚠️  Service discovery failed: {e}")
+                logging.warning("Service discovery failed: %s", e)
 
         logging.info(f"\n🚀 Starting HomeHub server on {config['server']['host']}:{config['server']['port']}")
         

--- a/run.py
+++ b/run.py
@@ -3,6 +3,8 @@
 Homehub - Main entry point
 """
 import os
+import logging
+from logging.handlers import RotatingFileHandler
 import argparse
 import sys
 import shutil
@@ -22,17 +24,68 @@ def cleanup_service():
 
 def signal_handler(signum, frame):
     """Handle shutdown signals"""
-    print("\n🛑 Shutting down HomeHub server...")
+    logging.info("\n🛑 Shutting down HomeHub server...")
     cleanup_service()
     sys.exit(0)
 
 def main():
     """Main entry point for the application"""
     global _service_discovery
-    
+
+    # Setup logging: unique log file per instance with rotation
+    log_dir = os.path.abspath('logs')
+    os.makedirs(log_dir, exist_ok=True)
+    logfile = os.path.join(log_dir, f'homehub_{os.getpid()}.log')
+
+    # Parse command line arguments early to check for debug mode
+    parser = argparse.ArgumentParser(description='Homehub')
+    parser.add_argument('-e', '--env', help='Environment (development, production)', default='production')
+    parser.add_argument('--no-discovery', action='store_true', help='Disable service discovery')
+    args, unknown = parser.parse_known_args()
+
+    # Set Flask debug environment variable for Flask 2.3+
+    if args.env:
+        if args.env.lower() == 'development':
+            os.environ['FLASK_DEBUG'] = '1'
+        else:
+            os.environ['FLASK_DEBUG'] = '0'
+
+    # Create Flask application (needed to get config)
+    app = create_app()
+    with app.app_context():
+        from app.config import get_config
+        config = get_config()
+        debug_mode = config['server'].get('debug', False)
+
+    # Set logging level based on debug mode
+    log_level = logging.DEBUG if debug_mode else logging.INFO
+    file_handler = RotatingFileHandler(logfile, maxBytes=5_000_000, backupCount=5)
+    handlers = [file_handler]
+    if debug_mode:
+        console_handler = logging.StreamHandler(sys.__stdout__)
+        console_handler.setLevel(log_level)
+        console_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s: %(message)s'))
+        handlers.append(console_handler)
+    logging.basicConfig(
+        handlers=handlers,
+        level=log_level,
+        format='%(asctime)s %(levelname)s: %(message)s'
+    )
+
+    # Redirect all print output (stdout/stderr) to the same rotating log file
+    log_print_file = open(logfile, 'a')
+    sys.stdout = log_print_file
+    sys.stderr = log_print_file
+
+    # Re-create app and config in the correct context for the rest of the function
+    app = create_app()
+    with app.app_context():
+        from app.config import get_config
+        config = get_config()
+
     # Check for ffmpeg
     if shutil.which('ffmpeg') is None:
-        print("ERROR: ffmpeg is not installed or not found in PATH. Please install ffmpeg to use this server.", file=sys.stderr)
+        logging.error("ERROR: ffmpeg is not installed or not found in PATH. Please install ffmpeg to use this server.")
         sys.exit(1)
 
     # Parse command line arguments
@@ -67,13 +120,13 @@ def main():
         os.makedirs(web_assets_dir, exist_ok=True)
         os.makedirs(thumb_dir, exist_ok=True)
 
-        # Print server information
-        print(f"🏠 Homehub Configuration:")
-        print(f"- Environment: {os.environ.get('FLASK_ENV', 'production')}")
-        print(f"- Videos directory: {root_dir}")
-        print(f"- Web assets directory: {web_assets_dir}")
-        print(f"- Supported extensions: {', '.join(config['video']['extensions'])}")
-        print(f"- Videos per page: {config['video']['per_page']}")
+        # Log server information
+        logging.info("🏠 Homehub Configuration:")
+        logging.info(f"- Environment: {os.environ.get('FLASK_ENV', 'production')}")
+        logging.info(f"- Videos directory: {root_dir}")
+        logging.info(f"- Web assets directory: {web_assets_dir}")
+        logging.info(f"- Supported extensions: {', '.join(config['video']['extensions'])}")
+        logging.info(f"- Videos per page: {config['video']['per_page']}")
 
         # Start service discovery
         if not args.no_discovery and config.get('discovery', {}).get('enabled', True):
@@ -86,11 +139,11 @@ def main():
                     service_name
                 )
             except ImportError:
-                print("⚠️  Service discovery not available. Install 'zeroconf' package for network discovery.")
+                logging.warning("⚠️  Service discovery not available. Install 'zeroconf' package for network discovery.")
             except Exception as e:
-                print(f"⚠️  Service discovery failed: {e}")
+                logging.warning(f"⚠️  Service discovery failed: {e}")
 
-        print(f"\n🚀 Starting HomeHub server on {config['server']['host']}:{config['server']['port']}")
+        logging.info(f"\n🚀 Starting HomeHub server on {config['server']['host']}:{config['server']['port']}")
         
         # Start the server
         try:
@@ -100,7 +153,7 @@ def main():
                 debug=config['server']['debug']
             )
         except KeyboardInterrupt:
-            print("\n🛑 Server stopped by user")
+            logging.info("\n🛑 Server stopped by user")
         finally:
             cleanup_service()
 

--- a/run.py
+++ b/run.py
@@ -15,6 +15,7 @@ from app import create_app
 # Global service discovery instance
 _service_discovery = None
 
+
 def cleanup_service():
     """Cleanup function for service discovery"""
     global _service_discovery
@@ -23,42 +24,40 @@ def cleanup_service():
         stop_service_discovery()
         _service_discovery = None
 
+
 def signal_handler(signum, frame):
     """Handle shutdown signals"""
     logging.info("\n🛑 Shutting down HomeHub server...")
     cleanup_service()
     sys.exit(0)
 
+
 def main():
     """Main entry point for the application"""
     global _service_discovery
 
-    # Setup logging: unique log file per instance with rotation
     log_dir = os.path.abspath('logs')
     os.makedirs(log_dir, exist_ok=True)
     logfile = os.path.join(log_dir, f'homehub_{os.getpid()}.log')
 
-    # Parse command line arguments early to check for debug mode
     parser = argparse.ArgumentParser(description='Homehub')
     parser.add_argument('-e', '--env', help='Environment (development, production)', default='production')
     parser.add_argument('--no-discovery', action='store_true', help='Disable service discovery')
-    args, unknown = parser.parse_known_args()
+    args = parser.parse_args()
 
-    # Set Flask debug environment variable for Flask 2.3+
     if args.env:
+        os.environ['FLASK_ENV'] = args.env
         if args.env.lower() == 'development':
             os.environ['FLASK_DEBUG'] = '1'
         else:
             os.environ['FLASK_DEBUG'] = '0'
 
-    # Create Flask application (needed to get config)
     app = create_app()
     with app.app_context():
         from app.config import get_config
         config = get_config()
         debug_mode = config['server'].get('debug', False)
 
-    # Set logging level based on debug mode
     log_level = logging.DEBUG if debug_mode else logging.INFO
     file_handler = RotatingFileHandler(logfile, maxBytes=5_000_000, backupCount=5)
     handlers = [file_handler]
@@ -70,66 +69,48 @@ def main():
     logging.basicConfig(
         handlers=handlers,
         level=log_level,
-        format='%(asctime)s %(levelname)s: %(message)s'
+        format='%(asctime)s %(levelname)s: %(message)s',
     )
 
-    # Redirect all print output (stdout/stderr) to the same rotating log file
-    log_print_file = open(logfile, 'a')
-    sys.stdout = log_print_file
-    sys.stderr = log_print_file
-
-    # Re-create app and config in the correct context for the rest of the function
-    app = create_app()
-    with app.app_context():
-        from app.config import get_config
-        config = get_config()
-
-    # Check for ffmpeg
     if shutil.which('ffmpeg') is None:
-        logging.error("ERROR: ffmpeg is not installed or not found in PATH. Please install ffmpeg to use this server.")
+        logging.error(
+            "ERROR: ffmpeg is not installed or not found in PATH. "
+            "Please install ffmpeg to use this server."
+        )
         sys.exit(1)
 
-    # Parse command line arguments
-    parser = argparse.ArgumentParser(description='Homehub')
-    parser.add_argument('-e', '--env', help='Environment (development, production)', default='production')
-    parser.add_argument('--no-discovery', action='store_true', help='Disable service discovery')
-    args = parser.parse_args()
-
-    # Set Flask environment
-    if args.env:
-        os.environ['FLASK_ENV'] = args.env
-
-    # Register cleanup handlers
     atexit.register(cleanup_service)
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
 
-    # Create Flask application
-    app = create_app()
-
-    # Use application context to access config
     with app.app_context():
         from app.config import get_config
         config = get_config()
 
-        # Create necessary directories
         root_dir = os.path.abspath(config['directories']['videos'])
         web_assets_dir = os.path.abspath(config['directories']['web_assets'])
         thumb_dir = os.path.join(web_assets_dir, "thumbnails")
 
-        os.makedirs(root_dir, exist_ok=True)
-        os.makedirs(web_assets_dir, exist_ok=True)
-        os.makedirs(thumb_dir, exist_ok=True)
+        try:
+            os.makedirs(root_dir, exist_ok=True)
+            os.makedirs(web_assets_dir, exist_ok=True)
+            os.makedirs(thumb_dir, exist_ok=True)
+        except OSError as e:
+            logging.error("ERROR: Unable to create required directories: %s", e)
+            sys.exit(1)
 
-        # Log server information
+        for path in (root_dir, web_assets_dir, thumb_dir):
+            if not (os.access(path, os.R_OK) and os.access(path, os.W_OK)):
+                logging.error("ERROR: Insufficient permissions for directory %s", path)
+                sys.exit(1)
+
         logging.info("🏠 Homehub Configuration:")
-        logging.info(f"- Environment: {os.environ.get('FLASK_ENV', 'production')}")
-        logging.info(f"- Videos directory: {root_dir}")
-        logging.info(f"- Web assets directory: {web_assets_dir}")
-        logging.info(f"- Supported extensions: {', '.join(config['video']['extensions'])}")
-        logging.info(f"- Videos per page: {config['video']['per_page']}")
+        logging.info("- Environment: %s", os.environ.get('FLASK_ENV', 'production'))
+        logging.info("- Videos directory: %s", root_dir)
+        logging.info("- Web assets directory: %s", web_assets_dir)
+        logging.info("- Supported extensions: %s", ', '.join(config['video']['extensions']))
+        logging.info("- Videos per page: %s", config['video']['per_page'])
 
-        # Start service discovery (skip werkzeug reloader parent to avoid duplicate ads)
         discovery_enabled = (
             not args.no_discovery
             and config.get('discovery', {}).get('enabled', True)
@@ -148,24 +129,29 @@ def main():
                 )
             except ImportError:
                 logging.warning(
-                    "Service discovery not available. Install the 'zeroconf' package for network discovery."
+                    "Service discovery not available. Install the 'zeroconf' package "
+                    "for network discovery."
                 )
             except Exception as e:
                 logging.warning("Service discovery failed: %s", e)
 
-        logging.info(f"\n🚀 Starting HomeHub server on {config['server']['host']}:{config['server']['port']}")
-        
-        # Start the server
+        logging.info(
+            "\n🚀 Starting HomeHub server on %s:%s",
+            config['server']['host'],
+            config['server']['port'],
+        )
+
         try:
             app.run(
                 host=config['server']['host'],
                 port=config['server']['port'],
-                debug=config['server']['debug']
+                debug=config['server']['debug'],
             )
         except KeyboardInterrupt:
             logging.info("\n🛑 Server stopped by user")
         finally:
             cleanup_service()
+
 
 if __name__ == "__main__":
     main()

--- a/run.py
+++ b/run.py
@@ -6,10 +6,30 @@ import os
 import argparse
 import sys
 import shutil
+import signal
+import atexit
 from app import create_app
+
+# Global service discovery instance
+_service_discovery = None
+
+def cleanup_service():
+    """Cleanup function for service discovery"""
+    global _service_discovery
+    if _service_discovery:
+        from app.utils.service_discovery import stop_service_discovery
+        stop_service_discovery()
+
+def signal_handler(signum, frame):
+    """Handle shutdown signals"""
+    print("\n🛑 Shutting down HomeHub server...")
+    cleanup_service()
+    sys.exit(0)
 
 def main():
     """Main entry point for the application"""
+    global _service_discovery
+    
     # Check for ffmpeg
     if shutil.which('ffmpeg') is None:
         print("ERROR: ffmpeg is not installed or not found in PATH. Please install ffmpeg to use this server.", file=sys.stderr)
@@ -18,11 +38,17 @@ def main():
     # Parse command line arguments
     parser = argparse.ArgumentParser(description='Homehub')
     parser.add_argument('-e', '--env', help='Environment (development, production)', default='production')
+    parser.add_argument('--no-discovery', action='store_true', help='Disable service discovery')
     args = parser.parse_args()
 
     # Set Flask environment
     if args.env:
         os.environ['FLASK_ENV'] = args.env
+
+    # Register cleanup handlers
+    atexit.register(cleanup_service)
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
 
     # Create Flask application
     app = create_app()
@@ -42,19 +68,41 @@ def main():
         os.makedirs(thumb_dir, exist_ok=True)
 
         # Print server information
-        print(f"Homehub Configuration:")
+        print(f"🏠 Homehub Configuration:")
         print(f"- Environment: {os.environ.get('FLASK_ENV', 'production')}")
         print(f"- Videos directory: {root_dir}")
         print(f"- Web assets directory: {web_assets_dir}")
         print(f"- Supported extensions: {', '.join(config['video']['extensions'])}")
         print(f"- Videos per page: {config['video']['per_page']}")
 
+        # Start service discovery
+        if not args.no_discovery and config.get('discovery', {}).get('enabled', True):
+            try:
+                from app.utils.service_discovery import start_service_discovery
+                service_name = config.get('discovery', {}).get('service_name', config['server'].get('name', 'HomeHub'))
+                _service_discovery = start_service_discovery(
+                    config['server']['host'],
+                    config['server']['port'],
+                    service_name
+                )
+            except ImportError:
+                print("⚠️  Service discovery not available. Install 'zeroconf' package for network discovery.")
+            except Exception as e:
+                print(f"⚠️  Service discovery failed: {e}")
+
+        print(f"\n🚀 Starting HomeHub server on {config['server']['host']}:{config['server']['port']}")
+        
         # Start the server
-        app.run(
-            host=config['server']['host'],
-            port=config['server']['port'],
-            debug=config['server']['debug']
-        )
+        try:
+            app.run(
+                host=config['server']['host'],
+                port=config['server']['port'],
+                debug=config['server']['debug']
+            )
+        except KeyboardInterrupt:
+            print("\n🛑 Server stopped by user")
+        finally:
+            cleanup_service()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

- Register Bonjour only once by skipping the Flask debug reloader parent process, preventing duplicate `_homehub._tcp` advertisements on reload.
- Advertise a stable hostname derived from `discovery.service_name` (for example `homehub-dev.local`) instead of appending the process ID on every start.
- Return the actual registered Bonjour hostname from `/api/info` so clients match what is published on the network.
- Skip mDNS when the server is bound to loopback, and route registration messages through logging.

## Test plan

- [ ] Start server in development: `python run.py -e development` and confirm a single Bonjour service appears (e.g. `dns-sd -B _homehub._tcp`)
- [ ] Verify `/api/info` `discovery.bonjour_service` matches the registered hostname
- [ ] Confirm HomeHub iOS client discovers the server on the LAN
- [ ] Restart server and confirm hostname stays stable (no PID suffix)
- [ ] Stop server and confirm Bonjour service is removed


Made with [Cursor](https://cursor.com)